### PR TITLE
Export "bind" object

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ React hook for easy routing within a Next.js app.
 import { useRoute } from 'use-next-route'
 
 function ProjectsLink() {
-  const { href, onClick } = useRoute('/projects')
+  const { bind } = useRoute('/projects')
   return (
-    <a href={href} onClick={onClick}>Projects</a>
+    <a {...bind}>Projects</a>
   )
 }
 ```
@@ -59,6 +59,7 @@ Returns an object with the following properties:
 
 * `href`: URL string for the route. Usually used for adding a `href` attribute to links.
 * `onClick`: This will navigate to the route and handle preventing the default mouse event if needed.
+* `bind`: Object containing `href` and `onClick`. Useful for props spreading.
 * `isActive`: If the current browser location starts with the `href`. Used for active states.
 * `navigate`: Navigate to the route.
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -133,6 +133,7 @@ function useRoute(url: UrlObject | string, options: RouteOptions = {}) {
   }
 
   return {
+    bind: { onClick, href: aliasHref },
     onClick,
     href: aliasHref,
     isActive,


### PR DESCRIPTION
Exporting `href` and `onClick` in a single object provides the opportunity for a cleaner/smaller API as they map directly to child props.

For example:

```javascript
const { bind } = useRoute(...);
// bind == { href: '...', onClick: ... }
return <a {...bind}>Go Home</a>
```